### PR TITLE
Reverting commit 54eb31dc16dcc67d0b689ed947bc53a038608c0e in hidapi.

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -222,9 +222,7 @@ static HANDLE open_device(const char *path, BOOL enumerate)
 {
 	HANDLE handle;
 	DWORD desired_access = (enumerate)? 0: (GENERIC_WRITE | GENERIC_READ);
-	DWORD share_mode = (enumerate)?
-	                      FILE_SHARE_READ|FILE_SHARE_WRITE:
-						  FILE_SHARE_READ | FILE_SHARE_WRITE;
+	DWORD share_mode = FILE_SHARE_READ|FILE_SHARE_WRITE;
 
 	handle = CreateFileA(path,
 		desired_access,
@@ -791,12 +789,6 @@ int HID_API_EXPORT HID_API_CALL hid_get_feature_report(hid_device *dev, unsigned
 		register_error(dev, "Send Feature Report GetOverLappedResult");
 		return -1;
 	}
-
-	/* bytes_returned does not include the first byte which contains the
-	   report ID. The data buffer actually contains one more byte than
-	   bytes_returned. */
-	bytes_returned++;
-
 	return bytes_returned;
 #endif
 }


### PR DESCRIPTION
signal11/hidapi@54eb31d
"The Windows DeviceIoControl() doesn't account for the report ID byte."
This appears to not do the right thing in Win8.1 nor in Win10. Rolling back to fix appears to fix the issue of hid report size failing is psmoveapi and allows us to revert the hid packet size hack needed to make psmoveapi work.
